### PR TITLE
Update weights_only due to change in default in torch 2.6+

### DIFF
--- a/applications/DeepSpeed-Chat/dschat/utils/data/data_utils.py
+++ b/applications/DeepSpeed-Chat/dschat/utils/data/data_utils.py
@@ -375,7 +375,7 @@ def create_prompt_dataset(local_rank,
         torch.save(train_dataset, train_fname)
         torch.save(eval_dataset, eval_fname)
     torch.distributed.barrier()
-    return torch.load(train_fname), torch.load(eval_fname)
+    return torch.load(train_fname, weights_only=False), torch.load(eval_fname, weights_only=False)
 
 
 class DataCollatorReward:

--- a/applications/DeepSpeed-Chat/dschat/utils/data/data_utils.py
+++ b/applications/DeepSpeed-Chat/dschat/utils/data/data_utils.py
@@ -375,7 +375,9 @@ def create_prompt_dataset(local_rank,
         torch.save(train_dataset, train_fname)
         torch.save(eval_dataset, eval_fname)
     torch.distributed.barrier()
-    return torch.load(train_fname, weights_only=False), torch.load(eval_fname, weights_only=False)
+    return torch.load(train_fname,
+                      weights_only=False), torch.load(eval_fname,
+                                                      weights_only=False)
 
 
 class DataCollatorReward:


### PR DESCRIPTION
Bug discovered when updating DeepSpeed runners to cuda 12.4 (which allows the download of torch 2.6+) means we need to make changes to this.  

- [x] Corresponding DeepSpeed PR: https://github.com/deepspeedai/DeepSpeed/pull/7000 (tests pass on the DeepSpeed side)
- [ ] Edit other instances of `weights_only` in DeepSpeedExamples