### PR TITLE
Fix #941: Correctly define choices for --reward-model as a tuple

### DIFF
--- a/applications/DeepSpeed-Chat/e2e_rlhf.py
+++ b/applications/DeepSpeed-Chat/e2e_rlhf.py
@@ -65,7 +65,7 @@ def parse_args():
         "--reward-model",
         type=lambda x: x.replace("facebook/opt-", ""),
         default="350m",
-        choices=("350m"),
+        choices=("350m", ),
         help="Which facebook/opt-* model to use for Reward (step 2)",
     )
     parser.add_argument(


### PR DESCRIPTION
Fixes #941

Problem Description:
In the e2e_rlhf.py script, the choices option for the --reward-model parameter was incorrectly defined as a string ("350m") instead of a single-element tuple ("350m",). This caused argparse to interpret it as a sequence of individual characters ('(', '3', '5', '0', 'm', ')') rather than a valid list of options.

Solution:
As suggested in issue #941, this commit changes the definition of choices to ("350m",) by adding a trailing comma after the string. This ensures it is correctly parsed as a tuple containing the single element "350m".

Testing:

The script correctly accepts the parameter when run with the valid option --reward-model 350m.
When run with an invalid option (e.g., --reward-model 123m), argparse correctly throws an "invalid choice" error.
The script correctly uses the default value when the --reward-model parameter is not provided.
Additional Notes (Optional):
Thanks to @ChenDaiwei-99 (the original reporter of the issue) for identifying the problem and suggesting the solution.
