### PR TITLE
Update submodule link to reflect https style

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "training/DeepSpeed-Domino/Megatron-LM"]
 	path = training/DeepSpeed-Domino/Megatron-LM
-	url = git@github.com:NVIDIA/Megatron-LM.git
+	url = https://github.com/NVIDIA/Megatron-LM.git


### PR DESCRIPTION
git style links may often not work, especially in CI servers as it requires 'ssh' key setup even for READ operations. 
Please accept the change to reflect https style links. 