### PR TITLE
Add an AutoTP equivalence check for uneven TP size

### DIFF
--- a/training/autotp_equivalence/.gitignore
+++ b/training/autotp_equivalence/.gitignore
@@ -1,0 +1,2 @@
+runs/
+__pycache__/

--- a/training/autotp_equivalence/README.md
+++ b/training/autotp_equivalence/README.md
@@ -1,0 +1,122 @@
+# AutoTP equivalence check
+
+Tensor parallelism partitions a layer's arithmetic across ranks. It is not
+supposed to change what the layer computes: an AutoTP=3 run and an AutoTP=1 run
+of the same model, on the same data, should train the same model.
+
+Existing AutoTP smoke tests check that a sharded run exits cleanly. That is a
+weak signal, because a shard cut on the wrong boundary also exits cleanly — it
+just trains a different model. This example compares the runs' loss curves
+instead, which distinguishes a correct partition from a plausible-looking wrong
+one.
+
+## The three configurations
+
+| | Split of Qwen3-0.6B's 16 attention / 8 KV heads | Role |
+|---|---|---|
+| AutoTP=1 | not split | baseline |
+| AutoTP=3 | **uneven** — 6/6/4 heads per rank | the case under test |
+| AutoTP=4 | **even** — 4/4/4/4 heads per rank | control |
+
+AutoTP=3 is the interesting one. Even splits divide every dimension exactly and
+so hide off-by-one bugs; an uneven split is where a shard boundary is most likely
+to be computed wrongly. It also forces the head count, rather than the raw
+element count, to drive the split — partitioning `q_proj`'s 2048 output features
+as 683/683/682 would land mid-head and corrupt the attention reshape.
+
+AutoTP=4 exists to calibrate the answer. Because it divides evenly, whatever gap
+it shows against the baseline is pure floating-point reassociation. If AutoTP=3
+drifts no more than AutoTP=4 does, the uneven split is contributing no error of
+its own — a much stronger statement than "AutoTP=3 stayed under some tolerance I
+picked".
+
+## Running it
+
+```
+cd training/autotp_equivalence
+
+bash run_gpu.sh 500 0,1,2,3   # accelerators, NCCL
+bash run_cpu.sh 500           # CPU, gloo
+```
+
+Each script runs `train.py` at all three widths and then diffs each sharded run
+against the AutoTP=1 baseline with `compare_loss.py`. Set `MASTER_PORT` if you
+want a CPU and a GPU run to proceed at the same time.
+
+## What is pinned, and why
+
+Anything that could make the runs diverge for a reason other than sharding is
+fixed:
+
+| | |
+|---|---|
+| **Data** | Batches come from a CPU generator seeded identically on every rank, so all ranks — and all runs — see the same tokens in the same order. AutoTP replicates the input across the tensor-parallel group, so ranks that disagreed on the batch would invalidate the comparison. |
+| **Precision** | fp32. bf16 rounding noise is orders of magnitude larger than the reassociation error being measured, and would mask a real bug. |
+| **Dropout** | Asserted to be zero at startup, so no RNG is consumed inside the forward. |
+| **Parallelism** | `world_size` must equal `autotp_size`. Spare ranks would silently become a data-parallel dimension, averaging gradients over more samples and changing what is being compared. |
+| **Threads** | The CPU runs cap `OMP_NUM_THREADS`, identically at every width. Without it each rank sizes its thread pool for the whole machine and several ranks oversubscribe it — 27s per step instead of 1.5s. |
+
+The training data is random tokens, so the loss itself is meaningless. What
+matters is only that differently-sharded runs agree on it.
+
+## Reading the result
+
+The runs are not expected to be bit-identical. Collective reductions sum partial
+results in a different order than a single rank does, so the curves differ by
+floating-point reassociation from the first step where a reduction feeds back
+into the weights. What distinguishes that from a bug is its shape:
+
+* **Reassociation error jitters.** It grows slowly and non-monotonically as the
+  runs' weights drift within the same basin, and the control run shows the same
+  amount of it.
+* **A sharding bug compounds.** The runs are optimizing different models, so the
+  gap grows steadily, does not come back, and the uneven split shows it while the
+  even control does not.
+
+`compare_loss.py` therefore checks every step rather than the final loss, prints
+the whole trajectory (sampled, with the worst step always shown), and reports the
+mean and worst relative gap.
+
+The first step is checked separately and far more tightly (`--forward-rtol`,
+default 1e-6). Both runs start from the same checkpoint and no optimizer step has
+happened yet, so a gap there is a wrong forward, not accumulated drift — training
+dynamics cannot be blamed for it.
+
+## Measured results
+
+500 steps, Qwen3-0.6B, fp32:
+
+| Backend | Sharding | seq_len | step 0 | mean rel | worst rel |
+|---|---|---|---|---|---|
+| NCCL, GPUs | AutoTP=3 (uneven) | 128 | `0.00e+00` | `7.69e-05` | `2.52e-03` (step 467) |
+| NCCL, GPUs | AutoTP=4 (even, control) | 128 | `0.00e+00` | `7.58e-05` | `2.72e-03` (step 467) |
+| gloo, CPU | AutoTP=3 (uneven) | 64 | `6.82e-08` | `2.75e-05` | `1.15e-03` (step 379) |
+| gloo, CPU | AutoTP=4 (even, control) | 64 | `6.82e-08` | `2.79e-05` | `2.39e-03` (step 379) |
+
+The uneven split and the even control land on top of each other. Their means
+agree to within a few percent, and on both backends the worst step is *the same
+step* — 467 on GPU, 379 on CPU — which says the spike belongs to the training
+trajectory at that point rather than to how the heads were divided. On CPU, and
+at the worst step on GPU, the even control is in fact the *further* of the two
+from the baseline.
+
+So the answer is not merely "AutoTP=3 stayed under the tolerance". It is that
+splitting 16 heads unevenly across 3 ranks costs nothing in accuracy beyond what
+an evenly-divisible tensor-parallel run already costs.
+
+Note that the GPU runs match exactly at step 0 while the CPU runs do not. gloo
+reduces in a different order than a single rank does, so the sharded forward is
+not bit-identical there — which is why the forward check uses a small tolerance
+rather than demanding equality.
+
+## Tests
+
+```
+cd training/autotp_equivalence
+python -m pytest tests/ -v
+```
+
+The tests cover `compare_loss.py`: that it accepts reassociation-scale noise,
+rejects a compounding gap, catches a wrong forward at the first step without
+mistaking later drift for one, reports the worst step rather than the last, and
+never hides the worst step when sampling a long run.

--- a/training/autotp_equivalence/compare_loss.py
+++ b/training/autotp_equivalence/compare_loss.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+"""Diff the loss curves of two OPSD runs that differ only in AutoTP size.
+
+Tensor parallelism partitions a layer's arithmetic across ranks; it is not
+supposed to change what the layer computes. So a run at AutoTP=3 and a run at
+AutoTP=1, given the same seed, data order and hyperparameters, must follow the
+same loss curve to within floating-point reassociation error. A shard that is
+cut on the wrong boundary still trains -- it just trains a different model --
+so a smoke test that only checks for a clean exit will not catch it. This does.
+
+The tolerance is relative, and the check is per-step rather than on the final
+loss alone: reassociation error should jitter around zero, while a genuine
+sharding bug compounds as the two runs' weights drift apart.
+
+The first step is checked separately and much more tightly: both runs start from
+the same checkpoint and no optimizer step has happened yet, so a gap there is a
+wrong forward rather than accumulated drift, and training dynamics cannot be
+blamed for it.
+
+Over a long run the two curves also drift apart under their own dynamics: the
+loss surface is not flat, so a 1e-7 gap at step 0 does not stay 1e-7 forever
+even when both runs are correct. The check therefore reports the whole
+trajectory and fails only on a gap that a correct implementation cannot produce.
+
+Usage:
+    python compare_loss.py runs/autotp1/metrics.jsonl runs/autotp3/metrics.jsonl
+"""
+
+import argparse
+import json
+import sys
+
+
+def load(path: str) -> list:
+    with open(path) as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("baseline", help="metrics.jsonl of the AutoTP=1 run")
+    parser.add_argument("candidate", help="metrics.jsonl of the sharded run")
+    parser.add_argument("--rtol", type=float, default=1e-2,
+                        help="largest tolerated relative loss gap at any step")
+    parser.add_argument("--forward-rtol", type=float, default=1e-6,
+                        help="largest tolerated relative gap at the first step, before any "
+                             "optimizer step has had a chance to amplify it")
+    parser.add_argument("--print-every", type=int, default=50,
+                        help="print one row every N steps (the worst step is always printed)")
+    args = parser.parse_args()
+
+    baseline = {r["step"]: r for r in load(args.baseline)}
+    candidate = {r["step"]: r for r in load(args.candidate)}
+
+    shared = sorted(set(baseline) & set(candidate))
+    if not shared:
+        print("no steps in common between the two runs", file=sys.stderr)
+        return 1
+    if len(shared) != len(baseline) or len(shared) != len(candidate):
+        print(f"warning: comparing {len(shared)} shared steps "
+              f"({len(baseline)} baseline, {len(candidate)} candidate)", file=sys.stderr)
+
+    gaps = []
+    for step in shared:
+        b = baseline[step]["loss"]
+        c = candidate[step]["loss"]
+        gaps.append((step, b, c, abs(c - b) / max(abs(b), 1e-12)))
+
+    worst_step, _, _, worst = max(gaps, key=lambda row: row[3])
+
+    print(f"{'step':>6} {'baseline':>13} {'candidate':>13} {'rel':>11}")
+    for step, b, c, rel in gaps:
+        if step % args.print_every == 0 or step == shared[-1] or step == worst_step:
+            marker = "  <- worst" if step == worst_step else ""
+            print(f"{step:>6} {b:>13.6f} {c:>13.6f} {rel:>11.2e}{marker}")
+
+    mean = sum(row[3] for row in gaps) / len(gaps)
+    first_step, _, _, first_rel = gaps[0]
+    print(f"\nsteps={len(gaps)} first_rel={first_rel:.2e} mean_rel={mean:.2e} "
+          f"worst_rel={worst:.2e} at step {worst_step}")
+
+    # The first step is the sharpest signal available: both runs start from the same
+    # checkpoint and no optimizer step has happened yet, so training dynamics cannot
+    # have amplified anything. A gap here is a wrong forward, not accumulated drift.
+    if first_rel > args.forward_rtol:
+        print(f"FAIL: the runs already disagree by {first_rel:.2e} at step {first_step}, "
+              f"before any weight update -- the sharded forward is wrong "
+              f"(tolerance {args.forward_rtol:.0e})",
+              file=sys.stderr)
+        return 1
+
+    if worst > args.rtol:
+        print(f"FAIL: loss diverges by {worst:.2e} at step {worst_step} "
+              f"(tolerance {args.rtol:.0e})", file=sys.stderr)
+        return 1
+    print(f"OK: {len(gaps)} steps agree within {args.rtol:.0e}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/training/autotp_equivalence/configs/autotp1.json
+++ b/training/autotp_equivalence/configs/autotp1.json
@@ -1,0 +1,23 @@
+{
+    "zero_optimization": {
+        "stage": 0
+    },
+    "tensor_parallel": {
+        "autotp_size": 1
+    },
+    "optimizer": {
+        "type": "AdamW",
+        "params": {
+            "lr": 1e-05,
+            "betas": [
+                0.9,
+                0.95
+            ],
+            "eps": 1e-08,
+            "weight_decay": 0.0,
+            "torch_adam": true
+        }
+    },
+    "gradient_clipping": 1.0,
+    "wall_clock_breakdown": false
+}

--- a/training/autotp_equivalence/configs/autotp3.json
+++ b/training/autotp_equivalence/configs/autotp3.json
@@ -1,0 +1,23 @@
+{
+    "zero_optimization": {
+        "stage": 0
+    },
+    "tensor_parallel": {
+        "autotp_size": 3
+    },
+    "optimizer": {
+        "type": "AdamW",
+        "params": {
+            "lr": 1e-05,
+            "betas": [
+                0.9,
+                0.95
+            ],
+            "eps": 1e-08,
+            "weight_decay": 0.0,
+            "torch_adam": true
+        }
+    },
+    "gradient_clipping": 1.0,
+    "wall_clock_breakdown": false
+}

--- a/training/autotp_equivalence/configs/autotp4.json
+++ b/training/autotp_equivalence/configs/autotp4.json
@@ -1,0 +1,23 @@
+{
+    "zero_optimization": {
+        "stage": 0
+    },
+    "tensor_parallel": {
+        "autotp_size": 4
+    },
+    "optimizer": {
+        "type": "AdamW",
+        "params": {
+            "lr": 1e-05,
+            "betas": [
+                0.9,
+                0.95
+            ],
+            "eps": 1e-08,
+            "weight_decay": 0.0,
+            "torch_adam": true
+        }
+    },
+    "gradient_clipping": 1.0,
+    "wall_clock_breakdown": false
+}

--- a/training/autotp_equivalence/run_cpu.sh
+++ b/training/autotp_equivalence/run_cpu.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Check that AutoTP does not change what a model computes, on CPU.
+#
+# Same comparison as run_gpu.sh but with the gloo backend and no accelerator, so
+# it also covers the CPU collectives path and runs anywhere. Slower per step, so
+# a shorter --seq_len keeps it practical.
+#
+#   AutoTP=1  the baseline
+#   AutoTP=3  an *uneven* split of Qwen3's 16 attention / 8 KV heads (6/6/4 per
+#             rank) -- the case a shard-boundary bug is most likely to hit
+#   AutoTP=4  an *even* split (4/4/4/4) -- the control. It divides every
+#             dimension exactly, so its gap to the baseline is pure
+#             floating-point reassociation. If AutoTP=3 drifts no more than
+#             AutoTP=4 does, the uneven split is not adding error of its own.
+#
+# Usage: bash run_cpu.sh [steps]
+set -e
+# Overridable so a CPU and a GPU run can proceed at the same time.
+MASTER_PORT=${MASTER_PORT:-29500}
+STEPS=${1:-500}
+export DS_ACCELERATOR=cpu
+# Without a cap each rank opens a thread pool sized for the whole machine, and
+# several of them oversubscribe it badly -- 27s per step here versus 1.5s. Every
+# run uses the same cap so the only difference between them stays the sharding.
+export OMP_NUM_THREADS=${OMP_NUM_THREADS:-16}
+
+rm -rf runs/cpu
+
+for tp in 1 3 4; do
+    deepspeed --master_port "${MASTER_PORT}" --num_accelerators "${tp}" train.py \
+        --deepspeed_config "configs/autotp${tp}.json" \
+        --metrics_file "runs/cpu/autotp${tp}.jsonl" --steps "${STEPS}" --seq_len 64
+done
+
+echo
+echo "===== AutoTP=3 (uneven 6/6/4) vs AutoTP=1 ====="
+python compare_loss.py runs/cpu/autotp1.jsonl runs/cpu/autotp3.jsonl --print-every 100
+
+echo
+echo "===== AutoTP=4 (even 4/4/4/4, control) vs AutoTP=1 ====="
+python compare_loss.py runs/cpu/autotp1.jsonl runs/cpu/autotp4.jsonl --print-every 100

--- a/training/autotp_equivalence/run_gpu.sh
+++ b/training/autotp_equivalence/run_gpu.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Check that AutoTP does not change what a model computes, on accelerators.
+#
+# Runs the same steps at three tensor-parallel widths and diffs each sharded run
+# against the unsharded one:
+#
+#   AutoTP=1  the baseline
+#   AutoTP=3  an *uneven* split of Qwen3's 16 attention / 8 KV heads (6/6/4 per
+#             rank) -- the case a shard-boundary bug is most likely to hit
+#   AutoTP=4  an *even* split (4/4/4/4) -- the control. It divides every
+#             dimension exactly, so its gap to the baseline is pure
+#             floating-point reassociation. If AutoTP=3 drifts no more than
+#             AutoTP=4 does, the uneven split is not adding error of its own.
+#
+# Usage: bash run_gpu.sh [steps] [four comma-separated gpu ids]
+set -e
+# Overridable so a CPU and a GPU run can proceed at the same time.
+MASTER_PORT=${MASTER_PORT:-29500}
+STEPS=${1:-500}
+GPUS=${2:-0,1,2,3}
+
+IFS=',' read -r -a GPU_LIST <<< "${GPUS}"
+if [ "${#GPU_LIST[@]}" -ne 4 ]; then
+    echo "need exactly 4 gpu ids, got '${GPUS}'" >&2
+    exit 1
+fi
+GPUS_1="${GPU_LIST[0]}"
+GPUS_3="${GPU_LIST[0]},${GPU_LIST[1]},${GPU_LIST[2]}"
+GPUS_4="${GPUS}"
+
+rm -rf runs/gpu
+
+for tp in "1:${GPUS_1}" "3:${GPUS_3}" "4:${GPUS_4}"; do
+    deepspeed --master_port "${MASTER_PORT}" --include "localhost:${tp#*:}" train.py \
+        --deepspeed_config "configs/autotp${tp%%:*}.json" \
+        --metrics_file "runs/gpu/autotp${tp%%:*}.jsonl" --steps "${STEPS}"
+done
+
+echo
+echo "===== AutoTP=3 (uneven 6/6/4) vs AutoTP=1 ====="
+python compare_loss.py runs/gpu/autotp1.jsonl runs/gpu/autotp3.jsonl --print-every 100
+
+echo
+echo "===== AutoTP=4 (even 4/4/4/4, control) vs AutoTP=1 ====="
+python compare_loss.py runs/gpu/autotp1.jsonl runs/gpu/autotp4.jsonl --print-every 100

--- a/training/autotp_equivalence/tests/test_compare_loss.py
+++ b/training/autotp_equivalence/tests/test_compare_loss.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+"""Tests for the AutoTP loss-curve comparison."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPARE = ROOT / "compare_loss.py"
+
+
+def _write(path: Path, losses, autotp_size=1) -> None:
+    with open(path, "w") as f:
+        for step, loss in enumerate(losses):
+            f.write(json.dumps({"step": step, "loss": loss, "autotp_size": autotp_size}) + "\n")
+
+
+def _compare(baseline: Path, candidate: Path, *extra):
+    return subprocess.run([sys.executable, str(COMPARE), str(baseline), str(candidate), *extra],
+                          capture_output=True,
+                          text=True)
+
+
+def test_identical_curves_agree(tmp_path):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [2.0, 1.5, 1.25])
+    _write(candidate, [2.0, 1.5, 1.25], autotp_size=3)
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 0, result.stderr
+    assert "worst_rel=0.00e+00" in result.stdout
+
+
+def test_reassociation_noise_is_accepted(tmp_path):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [2.0, 1.5, 1.25])
+    _write(candidate, [2.0 + 1e-6, 1.5 - 1e-6, 1.25 + 1e-6], autotp_size=3)
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 0, result.stderr
+    assert "OK: 3 steps agree" in result.stdout
+
+
+def test_a_drifting_curve_is_rejected(tmp_path):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [2.0, 1.5, 1.25])
+    # A wrongly sharded run trains a different model, so the gap compounds.
+    _write(candidate, [2.0, 1.6, 1.6], autotp_size=3)
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 1
+    assert "diverges" in result.stderr
+
+
+def test_the_worst_step_is_reported_not_the_last(tmp_path):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [1.0, 1.0, 1.0])
+    _write(candidate, [1.0, 1.5, 1.0], autotp_size=3)
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 1
+    assert "at step 1" in result.stderr
+
+
+def test_the_worst_step_is_always_printed(tmp_path):
+    """A long run prints a sample of steps, but never hides the worst one."""
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    losses = [1.0] * 200
+    _write(baseline, losses)
+    spiked = list(losses)
+    spiked[137] = 1.0001
+    _write(candidate, spiked, autotp_size=3)
+
+    result = _compare(baseline, candidate, "--print-every", "50")
+    assert result.returncode == 0, result.stderr
+    assert "<- worst" in result.stdout
+    worst_rows = [line for line in result.stdout.splitlines() if "<- worst" in line]
+    assert len(worst_rows) == 1
+    assert worst_rows[0].split()[0] == "137"
+
+
+def test_runs_with_no_shared_steps_fail(tmp_path):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [1.0])
+    candidate.write_text(json.dumps({"step": 7, "loss": 1.0}) + "\n")
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 1
+    assert "no steps in common" in result.stderr
+
+
+def test_a_truncated_run_warns_but_still_compares(tmp_path):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [1.0, 1.0, 1.0])
+    _write(candidate, [1.0, 1.0], autotp_size=3)
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 0, result.stderr
+    assert "warning: comparing 2 shared steps" in result.stderr
+
+
+def test_a_wrong_forward_is_caught_at_the_first_step(tmp_path):
+    """A gap before any weight update cannot be blamed on training dynamics."""
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [2.0, 1.5, 1.25])
+    _write(candidate, [2.001, 1.5, 1.25], autotp_size=3)
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 1
+    assert "the sharded forward is wrong" in result.stderr
+    # It must not be excused as drift: the overall gap is well inside --rtol.
+    assert "diverges" not in result.stderr
+
+
+def test_drift_after_the_first_step_is_not_a_forward_error(tmp_path):
+    """Later steps are held to the looser tolerance, since dynamics amplify noise."""
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [2.0, 1.5, 1.25])
+    _write(candidate, [2.0, 1.5008, 1.2506], autotp_size=3)
+
+    result = _compare(baseline, candidate)
+    assert result.returncode == 0, result.stderr
+    assert "first_rel=0.00e+00" in result.stdout
+
+
+def test_the_forward_tolerance_is_configurable(tmp_path):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    _write(baseline, [2.0, 1.5])
+    _write(candidate, [2.001, 1.5], autotp_size=3)
+
+    assert _compare(baseline, candidate, "--forward-rtol", "1e-2").returncode == 0
+
+
+@pytest.mark.parametrize("rtol, expected", [("1e-1", 0), ("1e-4", 1)])
+def test_the_tolerance_flag_is_honored(tmp_path, rtol, expected):
+    baseline, candidate = tmp_path / "b.jsonl", tmp_path / "c.jsonl"
+    # Step 0 matches, so only --rtol decides the outcome.
+    _write(baseline, [1.0, 1.0])
+    _write(candidate, [1.0, 1.01], autotp_size=3)
+
+    assert _compare(baseline, candidate, "--rtol", rtol).returncode == expected

--- a/training/autotp_equivalence/train.py
+++ b/training/autotp_equivalence/train.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+# DeepSpeed Team
+"""Train one model for N steps and record the loss of every step.
+
+The point of this script is to be run twice at different AutoTP sizes. Tensor
+parallelism partitions a layer's arithmetic across ranks; it is not supposed to
+change what the layer computes. So two runs that differ only in ``autotp_size``
+must follow the same loss curve, and ``compare_loss.py`` checks that they do.
+
+Everything that could make two runs diverge for reasons unrelated to sharding is
+pinned here:
+
+* the batches are drawn from a CPU generator seeded identically on every rank,
+  so all ranks -- and both runs -- see the same tokens in the same order (AutoTP
+  replicates the input across the tensor-parallel group, so ranks must agree);
+* weights are fp32, because bf16 rounding noise is far larger than the
+  reassociation error this is trying to measure;
+* the model must not consume RNG in its forward, or the two runs would diverge
+  through dropout rather than through sharding; this is asserted at startup
+  rather than assumed.
+
+The loss itself is not interesting -- the model is training on random tokens.
+What matters is that two differently-sharded runs agree on it.
+"""
+
+import argparse
+import json
+import os
+import time
+
+if os.environ.get("DS_ACCELERATOR") == "cpu":
+    # torch's AdamW probes the accelerator's current stream on every step. On a CPU
+    # run that still initializes a CUDA context, on a device picked by local rank,
+    # which fails outright if that device is busy -- and has nothing to do with the
+    # comparison. Hiding the GPUs before torch is imported keeps a CPU run on CPU.
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+import deepspeed
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--model_name_or_path", default="Qwen/Qwen3-0.6B")
+    parser.add_argument("--deepspeed_config", required=True)
+    parser.add_argument("--metrics_file", required=True, help="JSONL sink, one object per step")
+    parser.add_argument("--steps", type=int, default=500)
+    parser.add_argument("--seq_len", type=int, default=128)
+    parser.add_argument("--micro_batch_size", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--log_every", type=int, default=50)
+    parser.add_argument("--local_rank", type=int, default=-1)
+    return parser.parse_args()
+
+
+def batch_generator(seed: int) -> torch.Generator:
+    """A generator seeded the same way on every rank, so all ranks agree on the data.
+
+    The tensor-parallel group replicates its input, so ranks that disagreed on the
+    batch would make the comparison meaningless. Seeding on the CPU keeps the
+    stream identical regardless of accelerator.
+    """
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    return generator
+
+
+def assert_no_dropout(config) -> None:
+    """Refuse to compare runs whose forward would consume RNG."""
+    for name in ("attention_dropout", "hidden_dropout", "resid_pdrop", "embd_pdrop", "dropout"):
+        rate = getattr(config, name, 0.0)
+        if rate:
+            raise ValueError(f"{name}={rate}: dropout would make the two runs diverge through RNG "
+                             f"rather than through sharding")
+
+
+def main() -> None:
+    args = parse_args()
+    deepspeed.init_distributed()
+
+    torch.manual_seed(args.seed)
+    config = AutoConfig.from_pretrained(args.model_name_or_path)
+    assert_no_dropout(config)
+    model = AutoModelForCausalLM.from_pretrained(args.model_name_or_path, dtype=torch.float32)
+
+    with open(args.deepspeed_config) as f:
+        ds_config = json.load(f)
+    ds_config["train_micro_batch_size_per_gpu"] = args.micro_batch_size
+    ds_config["gradient_accumulation_steps"] = 1
+
+    autotp_size = ds_config.get("tensor_parallel", {}).get("autotp_size", 1)
+    world_size = torch.distributed.get_world_size()
+    if world_size != autotp_size:
+        # Spare ranks would become a data-parallel dimension, which averages gradients
+        # over more samples and changes what is being compared -- silently.
+        raise ValueError(f"world_size ({world_size}) must equal autotp_size ({autotp_size}); "
+                         f"this comparison is only meaningful without data parallelism")
+
+    engine, *_ = deepspeed.initialize(model=model, config=ds_config, model_parameters=model.parameters())
+
+    generator = batch_generator(args.seed)
+    device = engine.device
+    rank = torch.distributed.get_rank()
+
+    if rank == 0:
+        directory = os.path.dirname(args.metrics_file)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+        sink = open(args.metrics_file, "w")
+        print(f"[autotp_eq] model={args.model_name_or_path} autotp_size={autotp_size} "
+              f"world_size={world_size} steps={args.steps} seq_len={args.seq_len} dtype=float32")
+    else:
+        sink = None
+
+    started = time.time()
+    for step in range(args.steps):
+        input_ids = torch.randint(0,
+                                  config.vocab_size, (args.micro_batch_size, args.seq_len),
+                                  generator=generator,
+                                  dtype=torch.long).to(device)
+
+        loss = engine(input_ids=input_ids, labels=input_ids).loss
+        engine.backward(loss)
+        engine.step()
+
+        if rank == 0:
+            sink.write(json.dumps({"step": step, "loss": loss.item(), "autotp_size": autotp_size}) + "\n")
+            sink.flush()
+            if step % args.log_every == 0 or step == args.steps - 1:
+                print(f"[autotp_eq][step {step}] loss={loss.item():.6f} "
+                      f"elapsed={time.time() - started:.1f}s",
+                      flush=True)
+
+    if sink is not None:
+        sink.close()
+        print(f"[autotp_eq] wrote {args.steps} steps to {args.metrics_file} "
+              f"in {time.time() - started:.1f}s")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

* Verify deepspeedai/DeepSpeed#8185

The existing AutoTP smoke tests check that a sharded run exits cleanly. That is a
weak signal: a shard cut on the wrong boundary also exits cleanly, it just trains
a different model. This adds a check that compares what the runs actually compute.


### What it does

`train.py` trains one model for N steps and records every step's loss. Running it
at AutoTP=1 and AutoTP=3 and diffing the curves exercises the **uneven** split of
Qwen3's 16 attention / 8 KV heads (6/6/4 per rank), which is where a shard
boundary is most likely to be computed wrongly. Even splits divide every dimension
exactly and hide off-by-one bugs; an uneven split also forces the head count,
rather than the raw element count, to drive the partition. Splitting `q_proj`'s
2048 output features as 683/683/682 would land mid-head and corrupt the attention
reshape.

### Why there is a control run

A tolerance alone cannot settle whether an uneven split is *accurate*, only
whether it fits under a number chosen after the fact. So the runs also include
**AutoTP=4** as a control. It divides evenly, so its gap to the baseline is pure
floating-point reassociation, which calibrates what the uneven split ought to cost.

### Results — 500 steps, Qwen3-0.6B, fp32

| Backend | Sharding | seq_len | step 0 | mean rel | worst rel |
|---|---|---|---|---|---|
| NCCL, GPUs | AutoTP=3 (uneven) | 128 | `0.00e+00` | `7.69e-05` | `2.52e-03` (step 467) |
| NCCL, GPUs | AutoTP=4 (even, control) | 128 | `0.00e+00` | `7.58e-05` | **`2.72e-03`** (step 467) |
| gloo, CPU | AutoTP=3 (uneven) | 64 | `6.82e-08` | `2.75e-05` | `1.15e-03` (step 379) |
| gloo, CPU | AutoTP=4 (even, control) | 64 | `6.82e-08` | `2.79e-05` | **`2.39e-03`** (step 379) |

The uneven split and the even control land on top of each other. Their means agree
to within a few percent, and on both backends the worst step is *the same step*
(467 on GPU, 379 on CPU), with the even control the **further** of the two from
the baseline there. The spike belongs to the training trajectory at that point,
not to how the heads were divided.

So the conclusion is not merely "AutoTP=3 stayed under the tolerance". It is that
splitting 16 heads unevenly across 3 ranks costs nothing in accuracy beyond what
an evenly-divisible tensor-parallel run already costs.

The GPU runs match **exactly** at step 0 while the CPU runs differ by `6.82e-08`:
gloo reduces in a different order than a single rank does, so the sharded forward
is not bit-identical there. That is why the forward check uses a small tolerance
rather than demanding equality.

### What is pinned, and why

Anything that could make the runs diverge for a reason other than sharding is fixed:

| | |
|---|---|
| **Data** | Batches come from a CPU generator seeded identically on every rank, so all ranks and all runs see the same tokens in the same order. AutoTP replicates the input across the tensor-parallel group, so ranks that disagreed on the batch would invalidate the comparison. |
| **Precision** | fp32. bf16 rounding noise is orders of magnitude larger than the reassociation error being measured, and would mask a real bug. |
| **Dropout** | Asserted to be zero at startup, so no RNG is consumed inside the forward. |
| **Parallelism** | `world_size` must equal `autotp_size`. Spare ranks would silently become a data-parallel dimension, averaging gradients over more samples and changing what is being compared. |
| **Threads** | The CPU runs cap `OMP_NUM_THREADS` identically at every width. Without it each rank sizes its thread pool for the whole machine and several ranks oversubscribe it: 27s per step instead of 1.5s. |

The training data is random tokens, so the loss itself is meaningless. What matters
is only that differently-sharded runs agree on it.

### How the comparison reads

`compare_loss.py` checks every step rather than the final loss, because
reassociation error jitters while a sharding bug compounds. It checks the **first
step** far more tightly (`--forward-rtol`, default 1e-6): both runs start from the
same weights and no optimizer step has happened yet, so a gap there is a wrong
forward, not accumulated drift, and training dynamics cannot be blamed for it.

### Usage

```bash
cd training/autotp_equivalence
bash run_gpu.sh 500 0,1,2,3   # NCCL
bash run_cpu.sh 500           # gloo
python -m pytest tests/ -v
```

### Testing

- 500 steps at AutoTP=1/3/4 on GPUs (NCCL) and on CPU ranks (gloo); results above,
  reproducible bit-for-bit across repeated runs.
- 12 unit tests for `compare_loss.py`: accepts reassociation-scale noise, rejects a
  compounding gap, catches a wrong forward at the first step without mistaking later
  drift for one, reports the worst step rather than the last, and never hides the
  worst step when sampling a long run.